### PR TITLE
Copy raw bytes in splitter.lua for ~50x speed gain

### DIFF
--- a/lib/common/wav.lua
+++ b/lib/common/wav.lua
@@ -399,6 +399,9 @@ wav = {
 			-- Return audio handler
 			local obj
 			obj = {
+				get_file = function()
+					return file
+				end,
 				get_filename = function()
 					return filename
 				end,
@@ -667,6 +670,9 @@ wav = {
 
 			-- Return audio handler
 			return {
+				get_file = function()
+					return file
+				end,
 				get_filename = function()
 					return filename
 				end,


### PR DESCRIPTION
Splitting a monolith sample was way too slow to be useful, because there was tons of unneeded conversion between raw bytes and  sample values. Copying the raw sample bytes directly gives a massive speedup.

I think Pianobook deserves an automated pipeline for exporting DS and SFZ instruments consistently. Kontakt is a very limiting platform and does not align with the vision of Pianobook.