### PR TITLE
Improve RT pedal support, no round-robin hacks

### DIFF
--- a/lib/common/monolith.lua
+++ b/lib/common/monolith.lua
@@ -233,7 +233,8 @@ monolith = {
 
         if layer == 'RT' then
             sample_file = sample_file .. "_rt" 
-        elseif layer == 'PEDAL_UP' then
+        end
+        if layer == 'PEDAL_UP' then
             sample_file = sample_file .. "_pedal_up" 
         elseif layer == 'PEDAL_DOWN' then
             sample_file = sample_file .. "_pedal_down"             

--- a/splitter.lua
+++ b/splitter.lua
@@ -51,7 +51,7 @@ function process_layer(reader, layer, pedal, num_channels, sample_rate, bitrate)
         for rr=1,monolith.num_pedal_rr do
             local sample_file = monolith.get_file_name(file_prefix, layer, root, root, root, vol_low, vol_high, rr, pedal)
             copy_samples(layer, note_bar_in, note_duration_bars, reader, sample_file, num_channels, sample_rate, bitrate)
-            note_bar_in = note_bar_in + 6
+            note_bar_in = note_bar_in + monolith.get_bars_between_pedals()
         end 
     else 
         for i=0,monolith.num_zones-1 do


### PR DESCRIPTION
The Gimp was recorded with separate release triggers per pedal state, but they didn't seem to be used by the monolith library at all.

The round-robin implementation in `sfz.lua` was also strange, because there's no requirement for all samples to have equal round-robin lengths.