### PR TITLE
SFZ: Make velocity layers reach full volume at max velocity

### DIFF
--- a/lib/common/monolith.lua
+++ b/lib/common/monolith.lua
@@ -233,7 +233,8 @@ monolith = {
 
         if layer == 'RT' then
             sample_file = sample_file .. "_rt" 
-        elseif layer == 'PEDAL_UP' then
+        end
+        if layer == 'PEDAL_UP' then
             sample_file = sample_file .. "_pedal_up" 
         elseif layer == 'PEDAL_DOWN' then
             sample_file = sample_file .. "_pedal_down"             

--- a/sfz.lua
+++ b/sfz.lua
@@ -108,6 +108,7 @@ function process_layer(sample_file, prefix, layer, pedal)
         if layer == 'RT' then
             write_line('volume='..rt_volume)
             write_line('trigger=release_key')
+            write_line('amp_velcurve_1=0.1')
             write_line('seq_length=1')
             write_line('xfin_locc24=0')
             write_line('xfin_hicc24=127')
@@ -118,6 +119,7 @@ function process_layer(sample_file, prefix, layer, pedal)
             write_line('volume='..note_volume)
             write_line('xfin_locc23=0')
             write_line('xfin_hicc23=127')
+            write_line('amp_velcurve_'..vol_high..'=1')
             group_label = layer
         end
         if (pedal) then

--- a/splitter.lua
+++ b/splitter.lua
@@ -51,7 +51,7 @@ function process_layer(reader, layer, pedal, num_channels, sample_rate, bitrate)
         for rr=1,monolith.num_pedal_rr do
             local sample_file = monolith.get_file_name(file_prefix, layer, root, root, root, vol_low, vol_high, rr, pedal)
             copy_samples(layer, note_bar_in, note_duration_bars, reader, sample_file, num_channels, sample_rate, bitrate)
-            note_bar_in = note_bar_in + 6
+            note_bar_in = note_bar_in + monolith.get_bars_between_pedals()
         end 
     else 
         for i=0,monolith.num_zones-1 do


### PR DESCRIPTION
According to Christian's videos, the monolith sampling encourages not to normalize regions individually. Therefore, a velocity layer should reach full volume when played in its maximum velocity. When this is not accounted for, the relative volume between _piano_ and _fortissimo_ is not at all faithful to the original recording. This is not a problem with individually normalized samples.

For SFZ, this means using `amp_velcurve_N=1`, where `N` matches `hivel`.