### PR TITLE
Fix splitter.lua writing corrupt data chunks

### DIFF
--- a/splitter.lua
+++ b/splitter.lua
@@ -24,11 +24,8 @@ function copy_samples(note_name, bar_in, note_duration_bars, reader, sample_file
     local writer = wav.create_context(sample_file, "w")
     writer.init(num_channels, sample_rate, bitrate)
 
-    local file_r = reader.get_file()
-    local file_w = writer.get_file()
-
     local block_align = reader.get_block_align()
-    file_w:write(file_r:read((samples_out - samples_in) * block_align))
+    writer.write_raw_bytes(reader.read_raw_bytes((samples_out - samples_in) * block_align))
 
     writer.finish()
 end


### PR DESCRIPTION
Since #1, splitter.lua writes wav files without using the original wav reading interface. This way the data chunk will have no defined size and is simply `????`, which means a data chunk of size `0x3f3f3f3f`, meaning **1 GB**! Sforzando seems to deal with it, but this causes sfizz to allocate roughly a gigabyte of memory per sample.

This commit should fix the problem I caused. Please merge ASAP.